### PR TITLE
Don't show IP if request is terminated

### DIFF
--- a/portal/templates/request.html
+++ b/portal/templates/request.html
@@ -126,6 +126,8 @@
                               data-trigger="focus">
                                 {{request.headnode['ip']}}
                               </a>
+                              {% elif request.headnode['state'] == 'terminated' %}
+                              <small> N/A </small>        
                               {% else %}
                               <small>IP Not yet available</small>
                               {% endif %}


### PR DESCRIPTION
Having 'IP not yet available' doesnt make sense when the state is terminated. Changed to 'N/A'